### PR TITLE
Swift 1.2 -> 2.0

### DIFF
--- a/CommonCrypto/Info.plist
+++ b/CommonCrypto/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.hnormak.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/CommonCrypto/iphoneos.modulemap
+++ b/CommonCrypto/iphoneos.modulemap
@@ -1,4 +1,4 @@
 module CommonCrypto [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    header "/Applications/Xcode-beta.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/iphonesimulator.modulemap
+++ b/CommonCrypto/iphonesimulator.modulemap
@@ -1,4 +1,4 @@
 module CommonCrypto [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    header "/Applications/Xcode-beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/iphonesimulator.modulemap
+++ b/CommonCrypto/iphonesimulator.modulemap
@@ -1,4 +1,4 @@
 module CommonCrypto [system] {
-    header "/Applications/Xcode-beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator9.0.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/Example/HeimdallExample.xcodeproj/project.pbxproj
+++ b/Example/HeimdallExample.xcodeproj/project.pbxproj
@@ -213,7 +213,8 @@
 		8E05A4B11AE91F8C0047E970 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Henri Normak";
 				TargetAttributes = {
 					8E05A4B81AE91F8C0047E970 = {
@@ -368,6 +369,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -436,6 +438,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = HeimdallExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hnormak.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -446,6 +449,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = HeimdallExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hnormak.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -454,16 +458,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = HeimdallExampleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hnormak.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HeimdallExample.app/HeimdallExample";
 			};
@@ -473,12 +474,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = HeimdallExampleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hnormak.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HeimdallExample.app/HeimdallExample";
 			};

--- a/Example/HeimdallExample.xcodeproj/xcuserdata/henrinormak.xcuserdatad/xcschemes/HeimdallExample.xcscheme
+++ b/Example/HeimdallExample.xcodeproj/xcuserdata/henrinormak.xcuserdatad/xcschemes/HeimdallExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -62,6 +62,8 @@
             ReferencedContainer = "container:HeimdallExample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -71,6 +73,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Example/HeimdallExample/Info.plist
+++ b/Example/HeimdallExample/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.hnormak.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Example/HeimdallExample/ViewController.swift
+++ b/Example/HeimdallExample/ViewController.swift
@@ -73,7 +73,7 @@ class ViewController: UIViewController, UITextViewDelegate {
             self.view.setNeedsLayout()
             self.bottomConstraint.constant = CGRectGetHeight(intersection)
         
-            UIView.animateWithDuration(duration, delay: 0.0, options: UIViewAnimationOptions(curve), animations: { _ in
+            UIView.animateWithDuration(duration, delay: 0.0, options: UIViewAnimationOptions(rawValue: curve), animations: { _ in
                     self.view.setNeedsLayout()
                 }, completion: nil)
         }

--- a/Example/HeimdallExampleTests/Info.plist
+++ b/Example/HeimdallExampleTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.hnormak.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Heimdall.xcodeproj/project.pbxproj
+++ b/Heimdall.xcodeproj/project.pbxproj
@@ -198,7 +198,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8E866C6D1AE8FBEC005682A2 /* Build configuration list for PBXNativeTarget "HeimdallTests" */;
 			buildPhases = (
-				8E7DE8351AF9712600FDE3A7 /* CommonCrypto Module Map */,
 				8E866C5B1AE8FBEC005682A2 /* Sources */,
 				8E866C5C1AE8FBEC005682A2 /* Frameworks */,
 				8E866C5D1AE8FBEC005682A2 /* Resources */,
@@ -219,12 +218,10 @@
 		8E866C4B1AE8FBEC005682A2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Henri Normak";
 				TargetAttributes = {
-					8E3830791AFE176A007E4235 = {
-						CreatedOnToolsVersion = 6.3.1;
-					};
 					8E866C531AE8FBEC005682A2 = {
 						CreatedOnToolsVersion = 6.3;
 					};
@@ -290,20 +287,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "mapsDirectory=$SRCROOT/CommonCrypto\nplatform=$PLATFORM_NAME\nmoduleMap=$mapsDirectory/$platform.modulemap\nmoduleMapComparison=$mapsDirectory/$platform.modulemap.tmp\n\nmkdir -p \"$mapsDirectory\"\n\ncat > \"$moduleMapComparison\" << MAP\nmodule CommonCrypto [system] {\n    header \"$SDKROOT/usr/include/CommonCrypto/CommonCrypto.h\"\n    export *\n}\nMAP\n\ndiff \"$moduleMapComparison\" \"$moduleMap\" >/dev/null 2>/dev/null\nif [[ $? != 0 ]] ; then\nmv \"$moduleMapComparison\" \"$moduleMap\"\nelse\nrm \"$moduleMapComparison\"\nfi";
-		};
-		8E7DE8351AF9712600FDE3A7 /* CommonCrypto Module Map */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "CommonCrypto Module Map";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "modulesDirectory=$DERIVED_FILES_DIR/modules\nmodulesMap=$modulesDirectory/module.modulemap\nmodulesMapTemp=$modulesDirectory/module.modulemap.tmp\n\nmkdir -p \"$modulesDirectory\"\n\ncat > \"$modulesMapTemp\" << MAP\nmodule CommonCrypto [system] {\n    header \"$SDKROOT/usr/include/CommonCrypto/CommonCrypto.h\"\n    export *\n}\nMAP\n\ndiff \"$modulesMapTemp\" \"$modulesMap\" >/dev/null 2>/dev/null\nif [[ $? != 0 ]] ; then\nmv \"$modulesMapTemp\" \"$modulesMap\"\nelse\nrm \"$modulesMapTemp\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -405,6 +388,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -490,6 +474,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hnormak.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Heimdall;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -512,6 +497,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hnormak.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Heimdall;
 				SKIP_INSTALL = YES;
 			};
@@ -530,6 +516,7 @@
 				);
 				INFOPLIST_FILE = HeimdallTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hnormak.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -543,6 +530,7 @@
 				);
 				INFOPLIST_FILE = HeimdallTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hnormak.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Heimdall.xcodeproj/xcshareddata/xcschemes/Heimdall.xcscheme
+++ b/Heimdall.xcodeproj/xcshareddata/xcschemes/Heimdall.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -62,6 +62,8 @@
             ReferencedContainer = "container:Heimdall.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -71,6 +73,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Heimdall.xcodeproj/xcuserdata/henrinormak.xcuserdatad/xcschemes/CommonCrypto.xcscheme
+++ b/Heimdall.xcodeproj/xcuserdata/henrinormak.xcuserdatad/xcschemes/CommonCrypto.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -62,6 +62,8 @@
             ReferencedContainer = "container:Heimdall.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -71,6 +73,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Heimdall/Heimdall.swift
+++ b/Heimdall/Heimdall.swift
@@ -751,20 +751,20 @@ private extension NSData {
         
         // Container type and size
         builder.append(0x30)
-        builder.extend(totalLengthOctets)
+        builder.appendContentsOf(totalLengthOctets)
         data.appendBytes(builder, length: builder.count)
         builder.removeAll(keepCapacity: false)
         
         // Modulus
         builder.append(0x02)
-        builder.extend(modulusLengthOctets)
+        builder.appendContentsOf(modulusLengthOctets)
         data.appendBytes(builder, length: builder.count)
         builder.removeAll(keepCapacity: false)
         data.appendBytes(modulusBytes, length: modulusBytes.count)
         
         // Exponent
         builder.append(0x02)
-        builder.extend(exponentLengthOctets)
+        builder.appendContentsOf(exponentLengthOctets)
         data.appendBytes(builder, length: builder.count)
         data.appendBytes(exponentBytes, length: exponentBytes.count)
         
@@ -822,13 +822,13 @@ private extension NSData {
         // Overall size, made of OID + bitstring encoding + actual key
         let size = OID.count + 2 + encodingLength + self.length
         let encodedSize = size.encodedOctets()
-        builder.extend(encodedSize)
+        builder.appendContentsOf(encodedSize)
         result.appendBytes(builder, length: builder.count)
         result.appendBytes(OID, length: OID.count)
         builder.removeAll(keepCapacity: false)
         
         builder.append(0x03)
-        builder.extend((self.length + 1).encodedOctets())
+        builder.appendContentsOf((self.length + 1).encodedOctets())
         builder.append(0x00)
         result.appendBytes(builder, length: builder.count)
         

--- a/Heimdall/Info.plist
+++ b/Heimdall/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.hnormak.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/HeimdallTests/HeimdallTests.swift
+++ b/HeimdallTests/HeimdallTests.swift
@@ -45,21 +45,21 @@ class HeimdallTests: XCTestCase {
         customisedTags?.destroy()
         
         // Public key data based initialisation
-        let publicKeyData = NSData(base64EncodedString: "MIIBCgKCAQEA2Ddg4jCLE7VPxLPjBaTPH3DSXpkJQP3J5KycZBUF4dyWJTeY8m5HyTrRj+Dm5t3ccpPJSd+OjupHdUj+BtL+8g+NOddmUCr0gmQsxsXx8ex+lS+wHgRBmH/Cb/5lZ1Ml7Omtysz8G/pw6LGYK9C0s0ZoUOAApv/rC9vQ1T8S0eJPJIB8rHsfnvrxkC9Cwkftu5pOIv5fqrjsDLqn0dLypWyT8AhHSdgRZn0658efTyPytfnu2/1XiOzzCbNxPExv+n8fq1kkzSIg9+gN7tvPz+gpbv1eQsDkArrGx838EqW8o5cUbGA3DtlGWAr4dKTe3yY40CA55AMz/lvmU0dnRwIDAQAB", options: .allZeros)!
+        let publicKeyData = NSData(base64EncodedString: "MIIBCgKCAQEA2Ddg4jCLE7VPxLPjBaTPH3DSXpkJQP3J5KycZBUF4dyWJTeY8m5HyTrRj+Dm5t3ccpPJSd+OjupHdUj+BtL+8g+NOddmUCr0gmQsxsXx8ex+lS+wHgRBmH/Cb/5lZ1Ml7Omtysz8G/pw6LGYK9C0s0ZoUOAApv/rC9vQ1T8S0eJPJIB8rHsfnvrxkC9Cwkftu5pOIv5fqrjsDLqn0dLypWyT8AhHSdgRZn0658efTyPytfnu2/1XiOzzCbNxPExv+n8fq1kkzSIg9+gN7tvPz+gpbv1eQsDkArrGx838EqW8o5cUbGA3DtlGWAr4dKTe3yY40CA55AMz/lvmU0dnRwIDAQAB", options: [])!
         let pubData = Heimdall(publicTag: "public.initialisation", publicKeyData: publicKeyData)
         XCTAssertNotNil(pubData)
         pubData?.destroy()
         
         // Public key components based initialisation
-        let pubKeyModulus = NSData(base64EncodedString: "ANg3YOIwixO1T8Sz4wWkzx9w0l6ZCUD9yeSsnGQVBeHcliU3mPJuR8k60Y/g5ubd3HKTyUnfjo7qR3VI/gbS/vIPjTnXZlAq9IJkLMbF8fHsfpUvsB4EQZh/wm/+ZWdTJezprcrM/Bv6cOixmCvQtLNGaFDgAKb/6wvb0NU/EtHiTySAfKx7H5768ZAvQsJH7buaTiL+X6q47Ay6p9HS8qVsk/AIR0nYEWZ9OufHn08j8rX57tv9V4js8wmzcTxMb/p/H6tZJM0iIPfoDe7bz8/oKW79XkLA5AK6xsfN/BKlvKOXFGxgNw7ZRlgK+HSk3t8mONAgOeQDM/5b5lNHZ0c=", options: .allZeros)!
-        let pubKeyExponent = NSData(base64EncodedString: "AQAB", options: .allZeros)!
+        let pubKeyModulus = NSData(base64EncodedString: "ANg3YOIwixO1T8Sz4wWkzx9w0l6ZCUD9yeSsnGQVBeHcliU3mPJuR8k60Y/g5ubd3HKTyUnfjo7qR3VI/gbS/vIPjTnXZlAq9IJkLMbF8fHsfpUvsB4EQZh/wm/+ZWdTJezprcrM/Bv6cOixmCvQtLNGaFDgAKb/6wvb0NU/EtHiTySAfKx7H5768ZAvQsJH7buaTiL+X6q47Ay6p9HS8qVsk/AIR0nYEWZ9OufHn08j8rX57tv9V4js8wmzcTxMb/p/H6tZJM0iIPfoDe7bz8/oKW79XkLA5AK6xsfN/BKlvKOXFGxgNw7ZRlgK+HSk3t8mONAgOeQDM/5b5lNHZ0c=", options: [])!
+        let pubKeyExponent = NSData(base64EncodedString: "AQAB", options: [])!
         
         let pubComponents = Heimdall(publicTag: "public.components.initialisation", publicKeyModulus: pubKeyModulus, publicKeyExponent: pubKeyExponent)
         XCTAssertNotNil(pubComponents)
         pubComponents?.destroy()
         
         // Public X.509 data based initialisation
-        let publicKeyX509 = NSData(base64EncodedString: "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2Ddg4jCLE7VPxLPjBaTPH3DSXpkJQP3J5KycZBUF4dyWJTeY8m5HyTrRj+Dm5t3ccpPJSd+OjupHdUj+BtL+8g+NOddmUCr0gmQsxsXx8ex+lS+wHgRBmH/Cb/5lZ1Ml7Omtysz8G/pw6LGYK9C0s0ZoUOAApv/rC9vQ1T8S0eJPJIB8rHsfnvrxkC9Cwkftu5pOIv5fqrjsDLqn0dLypWyT8AhHSdgRZn0658efTyPytfnu2/1XiOzzCbNxPExv+n8fq1kkzSIg9+gN7tvPz+gpbv1eQsDkArrGx838EqW8o5cUbGA3DtlGWAr4dKTe3yY40CA55AMz/lvmU0dnRwIDAQAB", options: .allZeros)!
+        let publicKeyX509 = NSData(base64EncodedString: "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2Ddg4jCLE7VPxLPjBaTPH3DSXpkJQP3J5KycZBUF4dyWJTeY8m5HyTrRj+Dm5t3ccpPJSd+OjupHdUj+BtL+8g+NOddmUCr0gmQsxsXx8ex+lS+wHgRBmH/Cb/5lZ1Ml7Omtysz8G/pw6LGYK9C0s0ZoUOAApv/rC9vQ1T8S0eJPJIB8rHsfnvrxkC9Cwkftu5pOIv5fqrjsDLqn0dLypWyT8AhHSdgRZn0658efTyPytfnu2/1XiOzzCbNxPExv+n8fq1kkzSIg9+gN7tvPz+gpbv1eQsDkArrGx838EqW8o5cUbGA3DtlGWAr4dKTe3yY40CA55AMz/lvmU0dnRwIDAQAB", options: [])!
         
         let pubX509 = Heimdall(publicTag: "public.x509.initialisation", publicKeyData: publicKeyX509)
         XCTAssertNotNil(pubX509)

--- a/HeimdallTests/Info.plist
+++ b/HeimdallTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.hnormak.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Furthermore, Heimdall also helps maintain the public-private RSA key-pair in Key
 
 ## Requirements
 
-This branch of Heimdall requires Swift 2, and is only compatible with iOS 8 and above.
+This branch of Heimdall requires Swift 2 and works with only Xcode 7 Beta (iOS 9 SDK)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Furthermore, Heimdall also helps maintain the public-private RSA key-pair in Key
 
 ## Requirements
 
-Heimdall requires Swift 1.2, and is only compatible with iOS 8 and above.
+This branch of Heimdall requires Swift 2, and is only compatible with iOS 8 and above.
 
 ## Installation
 
@@ -22,7 +22,7 @@ Heimdall requires Swift 1.2, and is only compatible with iOS 8 and above.
 Heimdall is available as a CocoaPod, simply add the following line to your Podfile
 
 ```ruby
-pod 'Heimdall', '~> 0.1'
+pod 'Heimdall', :git => 'http://github.com/henrinormak/Heimdall', :branch => 'swift-2'
 ```
 
 Also, make sure your podfile includes the following line, which is necessary to support Swift frameworks
@@ -36,7 +36,7 @@ use_frameworks!
 Simply include the following line in your Cartfile
 
 ```
-github "henrinormak/Heimdall" ~> 0.1
+github "henrinormak/Heimdall" "swift-2"
 ```
 
 Note that Heimdall produces two frameworks in the Carthage build directory - `Heimdall.framework` and `CommonCrypto.framework`, you only need to include/embed `Heimdall.framework` into your project.


### PR DESCRIPTION
This signifies the release of Swift 2.0 and Heimdall moving onto it without backwards compatibility. Release 0.1.8 will remain the last with Swift 1.2 support, anything upwards of 0.2.0 will be Swift 2.0 and above only.
