### PR TITLE
Update iphonesimulator.modulemap

### DIFF
--- a/CommonCrypto/iphonesimulator.modulemap
+++ b/CommonCrypto/iphonesimulator.modulemap
@@ -1,4 +1,4 @@
 module CommonCrypto [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator9.0.sdk/usr/include/CommonCrypto/CommonCrypto.h"
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }


### PR DESCRIPTION
Was set to  iPhoneSimulator9.0.sdk. This should use the symlink instead of the specific simulator version as it will break with iPhoneSimulator9.x.sdk
