### PR TITLE
Added support for exporting private key data

### DIFF
--- a/Heimdall/Heimdall.swift
+++ b/Heimdall/Heimdall.swift
@@ -163,6 +163,13 @@ public class Heimdall {
     }
     
     ///
+    /// - returns: Private key data
+    ///
+    public func privateKeyData() -> NSData? {
+        return obtainKeyData(.Private)
+    }
+    
+    ///
     /// Encrypt an arbitrary string using AES256, the key for which
     /// is generated for a particular process and then encrypted with the
     /// public key from the RSA pair and prepended to the resulting data


### PR DESCRIPTION
Occasionally, the private key needs to be exported, e. g. if the user needs to transfer their data to another device or wants to create a backup. Allowing developers to have this functionality doesn't hurt.
