### PR TITLE
Renamed CommonCrypto in modulemap

### DIFF
--- a/CommonCrypto/appletvos.modulemap
+++ b/CommonCrypto/appletvos.modulemap
@@ -1,4 +1,4 @@
-module CommonCrypto [system] {
+module HeimdallCommonCrypto [system] {
     header "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/appletvsimulator.modulemap
+++ b/CommonCrypto/appletvsimulator.modulemap
@@ -1,4 +1,4 @@
-module CommonCrypto [system] {
+module HeimdallCommonCrypto [system] {
     header "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/iphoneos.modulemap
+++ b/CommonCrypto/iphoneos.modulemap
@@ -1,4 +1,4 @@
-module CommonCrypto [system] {
+module HeimdallCommonCrypto [system] {
     header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/CommonCrypto/iphonesimulator.modulemap
+++ b/CommonCrypto/iphonesimulator.modulemap
@@ -1,4 +1,4 @@
-module CommonCrypto [system] {
+module HeimdallCommonCrypto [system] {
     header "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }


### PR DESCRIPTION
Renamed CommonCrypto to HeimdallCommonCrypto to avoid modulemap conflict in xcode 10